### PR TITLE
Logo addition and CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11046,9 +11046,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -13039,9 +13039,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }

--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>NSS Cohort 36</title>
+    <title>NSS Cohort 44</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/home/About.css
+++ b/src/components/home/About.css
@@ -9,6 +9,8 @@ body {
     text-align: left;
     margin: 5%;
     color: black;
+    padding-top: 1em;
+    padding-bottom: 1em;
 }
 
 .hello {
@@ -44,11 +46,11 @@ body {
 }
 
 .about-background {
-    background-image: url(./about_background.png);
+    background-color: #F5F5F5;
 }
 
 #thanks {
-    background-image: url(./thanks_background.png);
+    background-color: #F5F5F5;
 }
 
 @media only screen and (max-width: 800px) {

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -68,21 +68,21 @@ class Home extends Component {
         <section id="about">
           <AboutUs />
         </section>
-        <Podcasts></Podcasts>
         <div id="devs" className="container-cards">
           {this.state.students.map(student =>
             <StudentCard
-              key={student.id}
-              student={student}
-              {...this.props}
+            key={student.id}
+            student={student}
+            {...this.props}
             />
-          )}
+            )}
         </div>
         <br />
         <br />
         <section id="tech">
           <Technologies />
         </section>
+        <Podcasts></Podcasts>
         <br />
         <br />
         <section id="thanks">

--- a/src/components/home/studentCard.css
+++ b/src/components/home/studentCard.css
@@ -9,7 +9,7 @@ body {
     display: flex;
     color: #ffffff;
     flex-direction: column;
-    background-color: #305c70;
+    background-color: #054F60;
     height: auto;
     width: 360px;
     margin: 1em;
@@ -39,6 +39,7 @@ body {
   color: white;
   margin: 8px;
 }
+
 
 .student-serious-photo, .student-fun-photo {
   width: 285px;
@@ -77,13 +78,13 @@ body {
 .icons {
   margin: 10px;
   font-size: 40px;
-  background-color: #305c70;
+  background-color: #054F60;
   color:rgb(241, 239, 239);
 }
 
 .icons:hover {
   margin: 10px;
-  background-color: #305c70;
+  background-color: #054F60;
   color: rgb(148, 146, 146);
 }
 
@@ -95,6 +96,7 @@ body {
   /* text-transform: uppercase; */
 
 }
+
 
 #hiredLabel {
   margin-bottom: 0;
@@ -116,7 +118,7 @@ body {
   margin-bottom: 0;
   height: 40px;
   border-radius: .43em .43em 0 0;
-  background-color: #ffffff;
+  background-color: #F5F5F5;
   /* background-image: linear-gradient(to right, rgb(42, 122, 208), rgb(25, 79, 255)); */
   color: #305c70;
   font-size: 24px;

--- a/src/components/nav/NavBar.css
+++ b/src/components/nav/NavBar.css
@@ -68,8 +68,9 @@ nav .container a:hover {
 }
 
 #classLogo {
-  height: 90px;
-  width: 90px;
+  max-width: 35%;
+  height: auto;
+  margin-left: 2em;
 }
 
 
@@ -81,10 +82,10 @@ nav .container a:hover {
     flex-direction: column;
     justify-content: center;
   }
-  #classLogo {
+  /* #classLogo {
     height: 31px;
     width: 31px;
-  }
+  } */
   .navbar-fixed-top {
     position: fixed;
     z-index: 100;

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { Link, withRouter } from "react-router-dom"
-import logo from './36logo.png'
 import './NavBar.css'
 import { Navbar, Nav, Button } from "react-bootstrap"
 // Author: Lauren Riddle
@@ -12,7 +11,24 @@ const NavBar = () => (
       <div className="flexContainer2">
         <nav className="flex-item navbar-fixed-top" id="navbar">
           <Navbar collapseOnSelect expand="lg" className="nav-width navbar-collapse">
-          <Navbar.Brand href="#home"><img src={logo} alt="Cohort 36 Logo" id="classLogo"></img></Navbar.Brand>
+          <Navbar.Brand href="#home">
+            <svg xmlns="http://www.w3.org/2000/svg" width="500.322" height="264.492" viewBox="0 0 366.322 264.492" id="classLogo">
+              <g id="Logo" transform="translate(-461.678 -677.508)">
+                <text id="_44" data-name="44" transform="translate(706 919)" fill="#000" font-size="170" font-family="HelveticaNeue, Helvetica Neue"><tspan x="0" y="0">44</tspan></text>
+                <text id="_44-2" data-name="44" transform="translate(700 919)" fill="#f05623" font-size="170" font-family="HelveticaNeue, Helvetica Neue"><tspan x="0" y="0">44</tspan></text>
+                <ellipse id="Ellipse_9" data-name="Ellipse 9" cx="103" cy="97" rx="103" ry="97" transform="translate(461.678 709.733) rotate(-9)" fill="#f05623"/>
+                <path id="Path_2" data-name="Path 2" d="M585.188,604.333" transform="translate(-47 212)" fill="none" stroke="#707070" stroke-width="1"/>
+                <ellipse id="Ellipse_19" data-name="Ellipse 19" cx="66.5" cy="65" rx="66.5" ry="65" transform="translate(508 724)" fill="#fff"/>
+                <ellipse id="Ellipse_20" data-name="Ellipse 20" cx="66.5" cy="65" rx="66.5" ry="65" transform="translate(522 736)" fill="#f05623"/>
+                <ellipse id="Ellipse_17" data-name="Ellipse 17" cx="53.5" cy="51" rx="53.5" ry="51" transform="translate(541 754)" fill="#fff"/>
+                <ellipse id="Ellipse_18" data-name="Ellipse 18" cx="53.5" cy="51" rx="53.5" ry="51" transform="translate(552 764)" fill="#f05623"/>
+                <ellipse id="Ellipse_14" data-name="Ellipse 14" cx="34" cy="34.5" rx="34" ry="34.5" transform="translate(579 789)" fill="#fff"/>
+                <ellipse id="Ellipse_15" data-name="Ellipse 15" cx="34" cy="34.5" rx="34" ry="34.5" transform="translate(588 797)" fill="#f05623"/>
+                <circle id="Ellipse_16" data-name="Ellipse 16" cx="11" cy="11" r="11" transform="translate(619 827)" fill="#fff"/>
+                <path id="Path_6" data-name="Path 6" d="M625.914,878.5c21.027.072,48.289,3.727,75.086,16.262,2.791,2.714-16.339-18.448-20.4-23.146-8.748-10.13-11.792-20.786-9.736-35.35C673.813,815.4,625.914,878.5,625.914,878.5Z" transform="translate(-1 -5)" fill="#f05623"/>
+              </g>
+            </svg>
+          </Navbar.Brand>
             <Navbar.Toggle aria-controls="responsive-navbar-nav" />
             <Navbar.Collapse id="responsive-navbar-nav" >
               <ul className="container" id="center-nav-elements">


### PR DESCRIPTION
# Description
The updated logo was added to the nav bar. I used svg code rather than an image file to ensure the image isn't pixelated. 

Seeing that the group photo will have several colors in it, I chose a soft muted gray for the about and thanks sections. Also, I changed the card color to a darker green that looks nice with the orange. Lastly, I put the podcast section at the bottom, because I think the student cards should be prioritized. 

## Type of change
- [x] Styling

# Testing Instructions
1. `git fetch --all`
1. `git checkout wb-logo`
1. View the logo, student card colors, about/thanks section background color.

